### PR TITLE
Fix suspension page typo

### DIFF
--- a/docs/admin/Customizing.md
+++ b/docs/admin/Customizing.md
@@ -21,7 +21,7 @@ A placeholder page is created whenever an account, addon domain, or subdomain is
 Copy `/usr/local/apnscp/resources/templates/apache/placeholder.blade.php` to `/usr/local/apnscp/config/custom/resources/templates/apache/placeholder.blade.php` creating parent directories as needed. index.html may not be updated once written.
 
 ### Suspension page
-All suspended accounts via [SuspendDomain](Plans#suspenddomain) redirect to `/var/www/html/suspend.html`. A suspension page is not provided by default in ApisCP but may be created by the admin. Suspension rules may be modified by adjusting the rewrite rules.
+All suspended accounts via [SuspendDomain](Plans#suspenddomain) redirect to `/var/www/html/suspended.html`. A suspension page is not provided by default in ApisCP but may be created by the admin. Suspension rules may be modified by adjusting the rewrite rules.
 
 Copy `/usr/local/apnscp/resources/templates/apache/suspend-rules.blade.php` to `/usr/local/apnscp/config/custom/resources/templates/apache/suspend-rules.blade.php` creating parent directories as needed.
 


### PR DESCRIPTION
Fix typo in `Customizing.md` as suspension page is `/var/www/html/suspended.html` by default, not `/var/www/html/suspend.html`.

https://gitlab.com/apisnetworks/apnscp/-/blob/a035b7dee086b44df7f27d1164879d50cb717b5d/resources/templates/apache/suspend-rules.blade.php#L3